### PR TITLE
feat(ansible): add ku, semver and scaffold installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ For kubernetes:
 * [kubecm](https://github.com/sunny0826/kubecm)
 * [kubevpn](https://www.kubevpn.cn/)
 * [kubie](https://github.com/sbstp/kubie)
+* [ku](https://github.com/bjarneo/ku)
 
 For markdown :
 
@@ -144,6 +145,8 @@ Development:
 * [chezmoi](https://github.com/twpayne/chezmoi)
 * [sops](https://github.com/getsops/sops)
 * [mise](https://github.com/jdx/mise)
+* [semver](https://github.com/sgaunet/semver)
+* [scaffold](https://github.com/sgaunet/scaffold)
 
 Linux tools :
 

--- a/src/roles/devops/tasks/main.yml
+++ b/src/roles/devops/tasks/main.yml
@@ -194,3 +194,13 @@
   ansible.builtin.include_role:
     name: sgaunet.gh_role_installer
     vars_from: mise.yml
+
+- name: "Install semver"
+  ansible.builtin.include_role:
+    name: sgaunet.gh_role_installer
+    vars_from: semver.yml
+
+- name: "Install scaffold"
+  ansible.builtin.include_role:
+    name: sgaunet.gh_role_installer
+    vars_from: scaffold.yml

--- a/src/roles/kubernetes/tasks/main.yml
+++ b/src/roles/kubernetes/tasks/main.yml
@@ -128,3 +128,8 @@
   ansible.builtin.include_role:
     name: sgaunet.gh_role_installer
     vars_from: kubie.yml
+
+- name: "Install ku"
+  ansible.builtin.include_role:
+    name: sgaunet.gh_role_installer
+    vars_from: ku.yml


### PR DESCRIPTION
## Overview
Add Ansible setup for three new tools exposed by the upcoming `ansible-role-gh-release-installer` release (new vars files: `ku.yml`, `semver.yml`, `scaffold.yml`).

## Changes
- `src/roles/devops/tasks/main.yml`: install **semver** (https://github.com/sgaunet/semver) and **scaffold** (https://github.com/sgaunet/scaffold)
- `src/roles/kubernetes/tasks/main.yml`: install **ku** (https://github.com/bjarneo/ku), a keyboard-driven Kubernetes TUI
- `README.md`: document the three tools

## Testing
- `ansible-lint` passes (production profile) on the modified task files

## Notes
Requires the new `sgaunet.gh_role_installer` release that ships the `ku.yml`, `semver.yml` and `scaffold.yml` vars files. A playbook run will fail against the current role version until it is published.

Closes #190